### PR TITLE
args_can_be_pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,12 @@
 
 ### git save
 
-    $ git save
+    $ git save [options]
 
 - commit with 'fixup! branch-name'
+- options pass to git commit command.
+  for example, It can use commit all modified files.
+  ex) "git save -a" is expand to "git commit -a -m 'fixup! branch-name'"
 
 ### git squash
 

--- a/bin/git-save
+++ b/bin/git-save
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 branch=`git branch | grep '*' | cut -f 2 -d ' '`
-git commit -m "fixup! $branch"
+git commit "${@}" -m "fixup! $branch"


### PR DESCRIPTION
Pass git-save command arguments to git-commit command.

I often use "git commit -am 'message'" for commit all modifications.
This PR allow same operation with git-save command.
